### PR TITLE
Replacing color-switcher to end of page for mobile layout

### DIFF
--- a/theme/styles/components/color-switcher.less
+++ b/theme/styles/components/color-switcher.less
@@ -56,6 +56,9 @@
 		.color-switcher-button {
 			display: inline-block;
 			transform: none;
+			&.active {
+				background: lighten(@first, 15%);
+			}
 		}
 	}
 }

--- a/theme/styles/components/color-switcher.less
+++ b/theme/styles/components/color-switcher.less
@@ -48,6 +48,14 @@
 		display: block;
 	}
   @media @media-m-max {
-		display: none;
+		position:relative;
+		text-align: center;
+		&.is-active {
+			position: relative;
+		}
+		.color-switcher-button {
+			display: inline-block;
+			transform: none;
+		}
 	}
 }


### PR DESCRIPTION
Nevím, zda bys raději vůbec nezobrazoval `color-picker`, ale zatím jsem to dělal tak, aby se posunul na konec stránky.