### PR TITLE
Přidat výpustek do náhledy článků

### DIFF
--- a/theme/styles/components/content.less
+++ b/theme/styles/components/content.less
@@ -41,8 +41,6 @@
 
 	&__excerpt {
 		text-align: left;
-		overflow: hidden;
-		max-height: 6.2rem;
 
 		p {
 			margin: 0.2em 0;

--- a/theme/utils/templating.php
+++ b/theme/utils/templating.php
@@ -47,7 +47,7 @@ MangoFilters::$set['wp_pubdate'] = function($id) {
 	return safe( get_the_time( get_option( 'date_format' ), $post));
 };
 
-MangoFilters::$set['wp_contexcerpt'] = function($id, $length = 55, $more = '&hellip;') {
+MangoFilters::$set['wp_contexcerpt'] = function($id, $length = 45, $more = '&hellip;') {
 	$post = lazy_post($id);
 	if(!$post) return $id;
 


### PR DESCRIPTION
Problém byl v tom, že se výpustek správně přidal (v templating.php), ale styly pak text uřízly na výšku. Jelikož css neumí snadno přidat výpustek po svislém přetečení (https://stackoverflow.com/questions/7004006/is-vertical-text-overflow-possible-with-css3) mi přišlo nejjednodušší ten excerpt zobrazit celý, a zároveň trochu zkrátit jeho délku, aby těch řádků nebylo přiliš. 